### PR TITLE
Update check_disk.sh

### DIFF
--- a/check_disk.sh
+++ b/check_disk.sh
@@ -43,7 +43,7 @@
 
 j=0; ok=0
 warn=0; crit=0
-COMMAND="/bin/df -PH"
+COMMAND="/bin/df -PHl -x tmpfs -x devtmpfs"
 TEMP_FILE="/var/tmp/df.$RANDOM"
 
 ## Help funcion
@@ -126,7 +126,7 @@ done
 
 ## Set the data to show in the nagios service status
 for (( i=1; i<=$EQP_FS; i++ )); do
-  DATA[$i]="${FSNAME[$i]} ${PERCENT[$i]}% of ${FULL[$i]},"
+  DATA[$i]="${FSNAME[$i]} ${PERCENT[$i]}% used of ${FULL[$i]} total - ${FREE[$i]} free,"
   perf[$i]="${FSNAME[$i]}=${PERCENT[$i]}%;${WARN};${CRIT};0;;"
 done
 


### PR DESCRIPTION
1.  Update the command to limit to "real" local disks.
2.  Update the data so that it is clear that the percentage is used and to include the value of remaining disk space (very useful on large volumes).

Example output:
OK. DISK STATS: / 62% used of 64G total -  23G free, /boot 26% used of 1.1G total -  747M free, /boot/efi 5% used of 262M total -  251M free, /home 60% used of 159G total -  61G free, /opt/data 66% used of 582G total -  190G free,